### PR TITLE
Add getIntersectionPoint() with 'includesEndpoint' parameter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 group = 'com.github.zawataki'
 archivesBaseName = 'intersection-point'
-version = '0.2.0'
+version = '0.3.0'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/com/github/zawataki/IntersectionPoint.java
+++ b/src/main/java/com/github/zawataki/IntersectionPoint.java
@@ -15,14 +15,30 @@ import java.util.Optional;
 public class IntersectionPoint {
 
     /**
-     * Get intersection point from given two lines
+     * Get intersection point from given two lines. If intersection point is on
+     * endpoint of a line, it's regarded as not intersected.
      *
-     * @param l1               1st line
-     * @param l2               2nd line
+     * @param l1 1st line
+     * @param l2 2nd line
      *
      * @return A intersection point if exists. Otherwise empty.
      */
     static public Optional<Point2D> getIntersectionPoint(Line2D l1, Line2D l2) {
+        return getIntersectionPoint(l1, l2, false);
+    }
+
+    /**
+     * Get intersection point from given two lines
+     *
+     * @param l1               1st line
+     * @param l2               2nd line
+     * @param includesEndpoint Includes endpoint of line if {@code true}.
+     *                         Otherwise excludes.
+     *
+     * @return A intersection point if exists. Otherwise empty.
+     */
+    static public Optional<Point2D> getIntersectionPoint(Line2D l1, Line2D l2,
+            boolean includesEndpoint) {
 
         // Line AB represented as a1x + b1y = c1
         final double a1 = l1.getP2().getY() - l1.getP1().getY();
@@ -47,17 +63,12 @@ public class IntersectionPoint {
                 new Point2D.Double(doubleToBigDecimal(x).doubleValue(),
                         doubleToBigDecimal(y).doubleValue());
 
-        if (!pointIsOnLineExcludesEndpoint(crossPoint, l1) ||
-                !pointIsOnLineExcludesEndpoint(crossPoint, l2)) {
+        if (!pointIsOnLine(crossPoint, l1, includesEndpoint) ||
+                !pointIsOnLine(crossPoint, l2, includesEndpoint)) {
             return Optional.empty();
         }
 
         return Optional.of(crossPoint);
-    }
-
-    static private boolean pointIsOnLineExcludesEndpoint(Point2D point,
-            Line2D line) {
-        return pointIsOnLine(point, line, false);
     }
 
     /**

--- a/src/test/java/com/github/zawataki/IntersectionPointTest.java
+++ b/src/test/java/com/github/zawataki/IntersectionPointTest.java
@@ -15,32 +15,84 @@ import static org.junit.Assert.assertThat;
 public class IntersectionPointTest {
 
     @Test
-    public void getIntersectionPoint_from_intersectedLines() {
+    public void getIntersectionPointFromIntersectedLines() {
         final Line2D line1 = new Line2D.Double(0, 0, 1, 1);
         final Line2D line2 = new Line2D.Double(1, 0, 0, 1);
 
-        final Optional<Point2D> intersectionPoint =
+        final Optional<Point2D> intersectionPointWhenExcludesEndpoint =
                 IntersectionPoint.getIntersectionPoint(line1, line2);
 
-        assertThat("Cannot get intersection point",
-                intersectionPoint.isPresent(), is(true));
+        assertThat("Cannot get intersection point when excludes endpoint",
+                intersectionPointWhenExcludesEndpoint.isPresent(), is(true));
 
         final Point2D.Double expectedIntersectionPoint =
                 new Point2D.Double(0.5, 0.5);
-        assertThat("Returned intersection point is NOT equal to " +
-                        expectedIntersectionPoint, intersectionPoint.get(),
+        assertThat("Returned intersection point when excludes endpoint, " +
+                        "is NOT equal to " + expectedIntersectionPoint,
+                intersectionPointWhenExcludesEndpoint.get(),
+                is(expectedIntersectionPoint));
+
+
+        final boolean includesEndpoint = true;
+        final Optional<Point2D> intersectionPointWhenIncludesEndpoint =
+                IntersectionPoint.getIntersectionPoint(line1, line2,
+                        includesEndpoint);
+
+        assertThat("Cannot get intersection point when includes endpoint",
+                intersectionPointWhenIncludesEndpoint.isPresent(), is(true));
+
+        assertThat("Returned intersection point when includes endpoint, " +
+                        "is NOT equal to " + expectedIntersectionPoint,
+                intersectionPointWhenIncludesEndpoint.get(),
                 is(expectedIntersectionPoint));
     }
 
     @Test
-    public void getIntersectionPoint_notIntersectedLines() {
+    public void getIntersectionPointFromNotIntersectedLines() {
         final Line2D line1 = new Line2D.Double(0, 0, 1, 1);
-        final Line2D line2 = new Line2D.Double(1, 1.1, 2, 2);
+        final Line2D line2 = new Line2D.Double(1, 1.0001, 2, 2);
 
-        final Optional<Point2D> intersectionPoint =
+        final Optional<Point2D> intersectionPointWhenExcludesEndpoint =
                 IntersectionPoint.getIntersectionPoint(line1, line2);
 
-        assertThat("Got intersection point", intersectionPoint.isPresent(),
-                is(false));
+        assertThat("Got intersection point when excludes endpoint",
+                intersectionPointWhenExcludesEndpoint.isPresent(), is(false));
+
+
+        final boolean includesEndpoint = true;
+        final Optional<Point2D> intersectionPointWhenIncludesEndpoint =
+                IntersectionPoint.getIntersectionPoint(line1, line2,
+                        includesEndpoint);
+
+        assertThat("Got intersection point when includes endpoint",
+                intersectionPointWhenIncludesEndpoint.isPresent(), is(false));
+    }
+
+    @Test
+    public void getIntersectionPointFromLinesIntersectedAtEndpoint() {
+        final Line2D line1 = new Line2D.Double(0, 0, 1, 1);
+        final Line2D line2 = new Line2D.Double(2, 0, 0, 2);
+
+        final Optional<Point2D> intersectionPointWhenExcludesEndpoint =
+                IntersectionPoint.getIntersectionPoint(line1, line2);
+
+        assertThat("Got intersection point when excludes endpoint",
+                intersectionPointWhenExcludesEndpoint.isPresent(), is(false));
+
+
+        final boolean includesEndpoint = true;
+        final Optional<Point2D> intersectionPointWhenIncludesEndpoint =
+                IntersectionPoint.getIntersectionPoint(line1, line2,
+                        includesEndpoint);
+
+        assertThat("Cannot get intersection point when includes endpoint",
+                intersectionPointWhenIncludesEndpoint.isPresent(), is(true));
+
+        final Point2D.Double expectedIntersectionPoint =
+                new Point2D.Double(1, 1);
+        assertThat("Returned intersection point when includes endpoint," +
+                        " is NOT equal to " + expectedIntersectionPoint,
+                intersectionPointWhenIncludesEndpoint.get(),
+                is(expectedIntersectionPoint));
     }
 }


### PR DESCRIPTION
Add getIntersectionPoint() method with 'includesEndpoint' parameter.
If 'includesEndpoint' is true, intersection judgement includes a endpoint of a line. Otherwise excludes it.